### PR TITLE
Now the template Helpers will be accessible always even where there is not data to use in template

### DIFF
--- a/underscore.template-helpers.js
+++ b/underscore.template-helpers.js
@@ -27,7 +27,11 @@
 			var template = originalUnderscoreTemplateFunction.apply( this, arguments );
 
 			var wrappedTemplate = function( data ) {
-				if( data ) _.defaults( data, templateHelpers );
+				if (!data) {
+	                            data = {};
+	                            arguments = [data];
+	                        }
+                      		_.defaults( data, templateHelpers );
 				return template.apply( this, arguments );
 			};
 


### PR DESCRIPTION
When the template didn't need data the default template helpers were undefined. 
Example

view:
this.$el.html(this.template());

template:
Title Blah Blah
<%= subview("sidedMultiSelects") %>

ReferenceError: subview is not defined -> I fixed that error
